### PR TITLE
Feat/api response parsing

### DIFF
--- a/server/src/main/java/com/innerpeace/innerpeace/calllassapi/controller/CallLassApiController.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/calllassapi/controller/CallLassApiController.java
@@ -1,21 +1,25 @@
 package com.innerpeace.innerpeace.calllassapi.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.innerpeace.innerpeace.calllassapi.dto.CallLassApiRequestDto;
-import com.innerpeace.innerpeace.calllassapi.dto.CallLassApiResponseDto;
+import com.innerpeace.innerpeace.calllassapi.dto.ResponseDto;
 import com.innerpeace.innerpeace.calllassapi.service.CallLassApiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/lass")
-public class CallLassApiController {
+@RequestMapping("/api/laas")
+public class CallLassApiController  {
 
     private final CallLassApiService callLassApiService;
 
     @PostMapping("/chat")
-    public ResponseEntity<CallLassApiResponseDto> callLassApi(@RequestBody CallLassApiRequestDto requestDto) {
+    public ResponseEntity<ResponseDto> callLassApi(@RequestBody CallLassApiRequestDto requestDto) throws JsonProcessingException {
 
         return ResponseEntity.ok(callLassApiService.requestChatCompletion(requestDto));
     }

--- a/server/src/main/java/com/innerpeace/innerpeace/calllassapi/dto/ResponseDto.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/calllassapi/dto/ResponseDto.java
@@ -1,0 +1,41 @@
+package com.innerpeace.innerpeace.calllassapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseDto {
+    private String text;
+    private List<TravelDay> travelSchedule;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TravelDay {
+        private String day;
+        private String date;
+        private List<Plan> plan;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Plan {
+        private int order;
+        private String place;
+        private String description;
+        private String activity;
+        private String image;
+        private double latitude;
+        private double longitude;
+    }
+}

--- a/server/src/main/java/com/innerpeace/innerpeace/calllassapi/service/CallLassApiService.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/calllassapi/service/CallLassApiService.java
@@ -1,7 +1,10 @@
 package com.innerpeace.innerpeace.calllassapi.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.innerpeace.innerpeace.calllassapi.dto.CallLassApiRequestDto;
-import com.innerpeace.innerpeace.calllassapi.dto.CallLassApiResponseDto;
+import com.innerpeace.innerpeace.calllassapi.dto.ResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -10,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -21,7 +26,9 @@ public class CallLassApiService {
     @Value("${laas.project.id}")
     private String projectId;
 
-    public CallLassApiResponseDto requestChatCompletion(CallLassApiRequestDto requestDto) {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public ResponseDto requestChatCompletion(CallLassApiRequestDto requestDto) throws JsonProcessingException{
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
@@ -48,6 +55,83 @@ public class CallLassApiService {
                 String.class
         );
 
-        return new CallLassApiResponseDto(response.getBody());
+
+        return getText(response);
+
     }
+
+    private ResponseDto getText(ResponseEntity<String> response) throws JsonProcessingException {
+        JsonNode root = objectMapper.readTree(response.getBody());
+        String contentJsonString = root
+                .path("choices")
+                .get(0)
+                .path("message")
+                .path("content")
+                .asText();
+
+        return parseTextToResponseDto(contentJsonString);
+    }
+
+    private ResponseDto parseTextToResponseDto(String text) {
+        List<ResponseDto.TravelDay> travelDays = new ArrayList<>();
+        ResponseDto.TravelDay currentDay = null;
+        List<ResponseDto.Plan> currentPlans = new ArrayList<>();
+
+        String[] lines = text.split("\\r?\\n");
+        ResponseDto.Plan currentPlan = null;
+
+        for (String line : lines) {
+            line = line.trim();
+
+            if (line.startsWith("Day")) {
+                if (currentDay != null) {
+                    currentDay.setPlan(currentPlans);
+                    travelDays.add(currentDay);
+                    currentPlans = new ArrayList<>();
+                }
+
+                String[] parts = line.split(" - ");
+                currentDay = new ResponseDto.TravelDay();
+                currentDay.setDay(parts[0].trim());
+                currentDay.setDate(parts.length > 1 ? parts[1].trim() : "");
+            } else if (line.startsWith("순서:")) {
+                currentPlan = new ResponseDto.Plan();
+                currentPlan.setOrder(Integer.parseInt(line.replace("순서:", "").trim()));
+            } else if (line.startsWith("장소:")) {
+                currentPlan.setPlace(line.replace("장소:", "").trim());
+            } else if (line.startsWith("활동:")) {
+                currentPlan.setActivity(line.replace("활동:", "").trim());
+            } else if (line.startsWith("설명:")) {
+                currentPlan.setDescription(line.replace("설명:", "").trim());
+            } else if (line.startsWith("이미지:")) {
+                currentPlan.setImage(line.replace("이미지:", "").trim());
+            } else if (line.startsWith("위도:")) {
+                try {
+                    currentPlan.setLatitude(Double.parseDouble(line.replace("위도:", "").trim()));
+                } catch (NumberFormatException e) {
+                    currentPlan.setLatitude(0.0);
+                }
+            } else if (line.startsWith("경도:")) {
+                try {
+                    currentPlan.setLongitude(Double.parseDouble(line.replace("경도:", "").trim()));
+                } catch (NumberFormatException e) {
+                    currentPlan.setLongitude(0.0);
+                }
+                currentPlans.add(currentPlan);
+            }
+        }
+
+        if (currentDay != null) {
+            currentDay.setPlan(currentPlans);
+            travelDays.add(currentDay);
+        }
+
+        ResponseDto responseDto = new ResponseDto();
+        responseDto.setText(text);           // 원본 텍스트 그대로 넣기
+        responseDto.setTravelSchedule(travelDays);  // 파싱한 일정 리스트 넣기
+        return responseDto;
+    }
+
+
+
 }

--- a/server/src/main/java/com/innerpeace/innerpeace/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.innerpeace.innerpeace.exception;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(JsonProcessingException.class)
+    public ResponseEntity<String> handleJsonProcessing(JsonProcessingException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("JSON 파싱 중 오류 발생: " + e.getMessage());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<String> handleRuntime(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("예상치 못한 오류: " + e.getMessage());
+    }
+
+
+}

--- a/server/src/main/java/com/innerpeace/innerpeace/util/ResponseParser.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/util/ResponseParser.java
@@ -1,0 +1,96 @@
+package com.innerpeace.innerpeace.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.innerpeace.innerpeace.calllassapi.dto.ResponseDto;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResponseParser {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ResponseParser() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+    /*
+    추출한 응답을 자바객체로 파싱하는 로직
+     */
+    public static ResponseDto parseTextToResponseDto(String text) {
+        List<ResponseDto.TravelDay> travelDays = new ArrayList<>();
+        ResponseDto.TravelDay currentDay = null;
+        List<ResponseDto.Plan> currentPlans = new ArrayList<>();
+
+        String[] lines = text.split("\\r?\\n");
+        ResponseDto.Plan currentPlan = null;
+
+        for (String line : lines) {
+            line = line.trim();
+
+            if (line.startsWith("Day")) {
+                if (currentDay != null) {
+                    currentDay.setPlan(currentPlans);
+                    travelDays.add(currentDay);
+                    currentPlans = new ArrayList<>();
+                }
+
+                String[] parts = line.split(" - ");
+                currentDay = new ResponseDto.TravelDay();
+                currentDay.setDay(parts[0].trim());
+                currentDay.setDate(parts.length > 1 ? parts[1].trim() : "");
+            } else if (line.startsWith("순서:")) {
+                currentPlan = new ResponseDto.Plan();
+                currentPlan.setOrder(Integer.parseInt(line.replace("순서:", "").trim()));
+            } else if (line.startsWith("장소:")) {
+                currentPlan.setPlace(line.replace("장소:", "").trim());
+            } else if (line.startsWith("활동:")) {
+                currentPlan.setActivity(line.replace("활동:", "").trim());
+            } else if (line.startsWith("설명:")) {
+                currentPlan.setDescription(line.replace("설명:", "").trim());
+            } else if (line.startsWith("이미지:")) {
+                currentPlan.setImage(line.replace("이미지:", "").trim());
+            } else if (line.startsWith("위도:")) {
+                try {
+                    currentPlan.setLatitude(Double.parseDouble(line.replace("위도:", "").trim()));
+                } catch (NumberFormatException e) {
+                    currentPlan.setLatitude(0.0);
+                }
+            } else if (line.startsWith("경도:")) {
+                try {
+                    currentPlan.setLongitude(Double.parseDouble(line.replace("경도:", "").trim()));
+                } catch (NumberFormatException e) {
+                    currentPlan.setLongitude(0.0);
+                }
+                currentPlans.add(currentPlan);
+            }
+        }
+
+        if (currentDay != null) {
+            currentDay.setPlan(currentPlans);
+            travelDays.add(currentDay);
+        }
+
+        ResponseDto responseDto = new ResponseDto();
+        responseDto.setText(text);
+        responseDto.setTravelSchedule(travelDays);
+        return responseDto;
+    }
+
+
+    /*
+    사용자에게 보여줄 응답 추출 로직
+     */
+    public static ResponseDto parseResponseEntity(ResponseEntity<String> response) throws JsonProcessingException {
+        JsonNode root = objectMapper.readTree(response.getBody());
+        String contentJsonString = root
+                .path("choices")
+                .get(0)
+                .path("message")
+                .path("content")
+                .asText();
+
+        return parseTextToResponseDto(contentJsonString);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #24 
> 
## 📝작업 내용
- Laas API 응답 텍스트를 `ResponseDto`로 파싱하는 로직 구현
- 파싱 메서드(`parseTextToResponseDto`)를 `ResponseParser` 유틸 클래스로 분리
- 날짜별 일정 및 장소 상세 계획(순서, 장소, 활동, 이미지 등) 파싱 처리
- 숫자 파싱 실패시 예외 처리 및 기본값 설정
- `CallLassApiService` 내부 로직 간소화 및 역할 분리
## 💬리뷰 요구사항
>
> 
