### PR TITLE
Refactor: 여행일정을 포함한 전체 텍스트 대신 AI 응답 텍스트만 저장하도록 변경

### DIFF
--- a/server/src/main/java/com/innerpeace/innerpeace/calllassapi/service/CallLaasApiService.java
+++ b/server/src/main/java/com/innerpeace/innerpeace/calllassapi/service/CallLaasApiService.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -35,11 +36,16 @@ public class CallLaasApiService {
         Map<String, Object> request = Map.of(
                 "hash", "7d58dfb6910ce0f5a240769143b43a62c65e1b716820632dff4761e19b0b1d49",
                 "params", Map.of(
-                        "유저입력", requestDto.getUserInput(),
                         "여행날짜", requestDto.getDate(),
                         "선호지역", requestDto.getRegion(),
                         "선호여행타입", requestDto.getTravelType(),
                         "이동수단", requestDto.getTransportation()
+                ),
+                "messages", List.of(
+                        Map.of(
+                                "role", "user",
+                                "content", requestDto.getUserInput()
+                        )
                 )
         );
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, headers);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #27 
> 
## 📝작업 내용
>  1.프리셋에서 ai응답내용을 innerpeace: 뒤에 보내도록 수정
>  2.innerpeace: 뒤에 오는 텍스트를 파싱하는 로직 추가
>  3. 유저의 메시지를 받는 방법 수정 -> 기존에 params에서 userInput을 받는 방법을 사용하였는데, 유저role의 메시지를 받는방식으로 변경
## 💬리뷰 요구사항
>  우리가 회의 했던 내용으로 출력되게 변경해 두었습니다.
> 코드 보고 궁금한점 있으면 연락주세요.
